### PR TITLE
Dependency removal, SSL filtering updates

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,3 +3,7 @@ source "https://supermarket.getchef.com"
 metadata
 
 cookbook 'stig'
+cookbook 'java'
+
+# The following is optional and only used if testing on the DOI network
+cookbook 'doi_ssl_filtering', github: "USGS-CIDA/chef-cookbook-doi-ssl-filtering", tag: 'v0.0.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+Tomcat Cookbook Changelog
+=========
+
+0.1.13
+------
+- [isuftin@usgs.gov] - Moved java installation out of dependencies cookbook. Should be done
+	at a higher level outside of this cookbook
+- [isuftin@usgs.gov] - Added DOI SSL helper cookbook to Berksfile. Only needs to exist in tests when
+	testing on DOI network
+
+0.1.12
+------
+- [isuftin@usgs.gov] - Updated to version 8.0.36 default for Tomcat. 
+- [isuftin@usgs.gov] - Added some documentation for getting SHA256 for binary
 
 0.1.12
 ------

--- a/recipes/install_deps.rb
+++ b/recipes/install_deps.rb
@@ -6,15 +6,5 @@
 # Description: Install all required dependencies in order to
 # install Tomcat
 
-# This IF check prevents two things
-# - Installing Java on top of aonther cookbook that may have installed it
-# - The Java cookbook used here is not idempotent as it keeps rewriting /etc/environment
-if !ENV['JAVA_HOME'] || ENV['JAVA_HOME'].strip.length == 0
-  include_recipe "java"
-else
-  Chef::Log.info "Java already installed at #{ENV['JAVA_HOME']}"
-  node.default["java"]["java_home"] = ENV['JAVA_HOME']
-end
-
 # gcc is needed to compile Tomcat's JSVC module
 package "gcc"


### PR DESCRIPTION
------
- [isuftin@usgs.gov] - Moved java installation out of dependencies cookbook. Should be done
	at a higher level outside of this cookbook
- [isuftin@usgs.gov] - Added DOI SSL helper cookbook to Berksfile. Only needs to exist in tests when
	testing on DOI network