### PR TITLE
Update to coordinate with java cookbook

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -3,7 +3,7 @@ source 'https://supermarket.getchef.com'
 metadata
 
 cookbook 'stig'
-cookbook 'java', '~> 1.43.0'
+cookbook 'java'
 
 # The following is optional and only used if testing on the DOI network
-cookbook 'doi_ssl_filtering', github: 'USGS-CIDA/chef-cookbook-doi-ssl-filtering', tag: 'v1.0.0'
+cookbook 'doi_ssl_filtering', github: 'USGS-CIDA/chef-cookbook-doi-ssl-filtering', tag: 'v1.0.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Tomcat Cookbook Changelog
 =========
 
+1.0.1
+-----
+- [isuftin@usgs.gov] - Use the third party Java cookbook's java_home attribtue to
+dictate JAVA_HOME for this cookbook. The Java cookbook version 1.47.0 introduced
+breaking changes for this
+
 1.0.0
 -----
 - [isuftin@usgs.gov] - Created a Tomcat application resource which provides the

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license          'Public Domain'
 description      'Installs and configures the Apache Tomcat servlet container '
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
-version          '1.0.0'
+version          '1.0.1'
 supports         'centos', '>= 6.5'
 
 depends 'java'

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -220,7 +220,7 @@ def load_service_definitions_and_keys(service_definitions)
       bash 'make_truststore' do
         cwd ssl_dir
         code <<-EOH
-        cp $JAVA_HOME/jre/lib/security/cacerts #{ssl_dir}/truststore
+        cp #{node['java']['java_home']}/jre/lib/security/cacerts #{ssl_dir}/truststore
         keytool -storepasswd -keystore truststore -storepass changeit -new #{keystore_password}
         EOH
         sensitive true

--- a/recipes/commons_daemon.rb
+++ b/recipes/commons_daemon.rb
@@ -10,11 +10,7 @@ group_name = node['wsi_tomcat']['group']['name']
 tomcat_home = node['wsi_tomcat']['user']['home_dir']
 unpack_directory = "#{Chef::Config[:file_cache_path]}/opt/commons_daemon"
 work_directory = "#{unpack_directory}/unix"
-java_home = -> { node['java']['java_home'] } # This needs lazy evaluation
-# TODO: Does java_home still need lazy evaluation now that the JAVA cookbook
-# has been moved out as a dependency of this cookbook?
-# node["java"]["java_home"] may not even exist if the cookbook author
-# decides not to use the JAVA cookbook
+java_home = node['java']['java_home']
 
 directory 'Create BCDP build dir' do
   path unpack_directory
@@ -33,11 +29,11 @@ execute 'Unpack BCDP source' do
 end
 
 execute 'Run configure on BCDP source' do
-  command "./configure --with-java=#{java_home.call}"
+  command "./configure --with-java=#{java_home}"
   user user_name
   group group_name
   cwd work_directory
-  environment 'JAVA_HOME' => java_home.call
+  environment 'JAVA_HOME' => java_home
   not_if { File.exist?("#{work_directory}/config.status") || File.exist?("#{tomcat_home}/bin/jsvc") }
 end
 


### PR DESCRIPTION
Use the third party Java cookbook's java_home attribtue to dictate JAVA_HOME for this cookbook. The Java cookbook version 1.47.0 introduced
breaking changes for this