### PR TITLE
Auto deploy

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -9,8 +9,7 @@ driver:
 
 provisioner:
   name: chef_zero
-  product_name: chefdk
-  product_version: 12.21.20
+  require_chef_omnibus: "12.21.20"
 
 verifier:
   name: inspec

--- a/libraries/manager_client.rb
+++ b/libraries/manager_client.rb
@@ -116,7 +116,7 @@ module Helper
         response = f.read
         status = response.split(' ')[0]
         raise response unless status == 'OK'
-        Chef::Log.info "Deplopyed new application to #{application_path}"
+        Chef::Log.info "Deployed new application to #{application_path}"
         return response
       end
     rescue => e

--- a/recipes/deploy_application.rb
+++ b/recipes/deploy_application.rb
@@ -52,7 +52,6 @@ node['wsi_tomcat']['instances'].each do |instance, attributes|
         deployed_apps = Helper::ManagerClient.get_deployed_applications(port, tomcat_script_pass)
         deployed_apps.each do |_path, _state, _session_count, name|
           version = name.split('#').length > 1 ? name.split('#')[-1] : ''
-          #name = name.split('#').length > 1 ? name.split('#')[-3] : name
           # Don't delete the manager app
           next unless name != 'manager'
           next if attributes.application.keys.include?(name)

--- a/recipes/deploy_application.rb
+++ b/recipes/deploy_application.rb
@@ -50,7 +50,7 @@ node['wsi_tomcat']['instances'].each do |instance, attributes|
       begin
         port = Helper::TomcatInstance.ports(node, instance)[0]
         deployed_apps = Helper::ManagerClient.get_deployed_applications(port, tomcat_script_pass)
-        deployed_apps.each do |_path, _state, _session_count, name|
+        deployed_apps.each do |path, _state, _session_count, name|
           version = name.split('#').length > 1 ? name.split('#')[-1] : ''
           # Don't delete the manager app
           next unless name != 'manager'
@@ -64,7 +64,7 @@ node['wsi_tomcat']['instances'].each do |instance, attributes|
           app.name name
           app.instance_name instance
           app.version version
-          app.path _path
+          app.path path
           app.run_action(:undeploy)
         end
       rescue => e

--- a/recipes/deploy_application.rb
+++ b/recipes/deploy_application.rb
@@ -52,7 +52,7 @@ node['wsi_tomcat']['instances'].each do |instance, attributes|
         deployed_apps = Helper::ManagerClient.get_deployed_applications(port, tomcat_script_pass)
         deployed_apps.each do |_path, _state, _session_count, name|
           version = name.split('#').length > 1 ? name.split('#')[-1] : ''
-          name = name.split('#').length > 1 ? name.split('#')[1] : name
+          #name = name.split('#').length > 1 ? name.split('#')[-3] : name
           # Don't delete the manager app
           next unless name != 'manager'
           next if attributes.application.keys.include?(name)
@@ -65,7 +65,7 @@ node['wsi_tomcat']['instances'].each do |instance, attributes|
           app.name name
           app.instance_name instance
           app.version version
-          app.path oath
+          app.path _path
           app.run_action(:undeploy)
         end
       rescue => e

--- a/resources/application.rb
+++ b/resources/application.rb
@@ -90,11 +90,11 @@ action :deploy do
   end
 
   if application_deployed?
-    Chef::Log.info "Application #{full_name} already deployed"
+    Chef::Log.info "Application #{name} already deployed"
     return true
   end
 
-  Chef::Log.info("Deploying #{full_name} at #{path} from #{location}")
+  Chef::Log.info("Deploying #{name} at #{path} from #{location}")
 
   artifact_directory = ::File.join(node['wsi_tomcat']['user']['home_dir'], 'instance', instance_name, 'artifacts')
   artifact_filename = "#{name}#{'_' + version unless version.to_s.strip.empty?}.#{type}"

--- a/resources/application.rb
+++ b/resources/application.rb
@@ -89,16 +89,17 @@ action :deploy do
     Chef::Application.fatal!('tomcat_application resource deploy action requires a type')
   end
 
-  if application_deployed?
+  artifact_directory = ::File.join(node['wsi_tomcat']['user']['home_dir'], 'instance', instance_name, 'artifacts')
+  artifact_filename = "#{name}#{'_' + version unless version.to_s.strip.empty?}.#{type}"
+  artifact_destination = ::File.join(artifact_directory, artifact_filename)
+
+  if ::File.exist?(artifact_destination)
     Chef::Log.info "Application #{name} already deployed"
     return true
   end
 
-  Chef::Log.info("Deploying #{name} at #{path} from #{location}")
+  Chef::Log.info("Deploying #{full_name} at #{path} from #{location}")
 
-  artifact_directory = ::File.join(node['wsi_tomcat']['user']['home_dir'], 'instance', instance_name, 'artifacts')
-  artifact_filename = "#{name}#{'_' + version unless version.to_s.strip.empty?}.#{type}"
-  artifact_destination = ::File.join(artifact_directory, artifact_filename)
   tomcat_user = node['wsi_tomcat']['user']['name']
   tomcat_group = node['wsi_tomcat']['user']['group']
 
@@ -114,10 +115,16 @@ action :deploy do
     backup false
   end
 
-  ruby_block "Deploy #{name}" do
-    block do
-      Helper::ManagerClient.deploy_application(instance_port, instance_script_pass, version, artifact_destination, path, tag)
-    end
+  webapps_directory = ::File.join(node['wsi_tomcat']['user']['home_dir'], 'instance', instance_name, 'webapps')
+  webapps_filename = "#{name}.#{type}"
+  webapps_destination = ::File.join(webapps_directory, webapps_filename)
+
+  bash 'copy_war_file' do
+    cwd artifact_directory
+    user tomcat_user
+    code <<-EOF
+	  cp #{artifact_filename} #{webapps_destination}
+	EOF
   end
 end
 


### PR DESCRIPTION
@isuftin - It turns out I didn't make any changes in the cookbook to enable new application versions to be deployed through the cookbook (and previous versions to be undeployed).  The easiest way I could find to handle the deploy/undeploy was to specify the applications like this in the environment:

              "datachecks_1.0.5": {
                "type": "war",
                "path": "/datachecks_1.0.5",
                "location": "http://cida.usgs.gov/maven/service/local/artifact/maven/redirect?r=cida-public-releases&g=gov.usgs.cida&a=data-checks-ui&v=1.0.5&e=war"
              }

Specifically, adding the "_version" to the name and path.  Trying the incorporate the "version" attribute was very confusing and I think would require a lot of rework.  Anyway, let me know if you're ok with this approach.  This pull request just contains some minor unrelated changes.
