### PR TITLE
Fix deployment and server checking process

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -30,6 +30,7 @@ suites:
       - recipe[wsi_tomcat::create_tomcat_base]
       - recipe[wsi_tomcat::create_tomcat_instances]
       - recipe[wsi_tomcat::update_context]
+      - recipe[wsi_tomcat::undeploy_application]
       - recipe[wsi_tomcat::deploy_application]
     data_path: test/files
     data_bags_path: './test/integration/default/data_bags/'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ Tomcat Cookbook Changelog
 
 Unreleased
 ---
+
+- [isuftin@usgs.gov] - In the manager client, the "get_deployed_applications"
+function now performs retries
+- [isuftin@usgs.gov] - Created a new recipe "undeploy_application" and moved the
+application undeploy functionality from the "deploy_application" recipe to this
+new recipe. This is a breaking change if you previously depended on the
+"deploy_application" to also undeploy applications for you
+- [isuftin@usgs.gov] - In the tomcat_application resource, added functionality
+to re-try if the "get deployed applications" function didn't work the first time
 - [isuftin@usgs.gov] - Fix version passing into update_context recipe
 - [isuftin@usgs.gov] - Updated mime types in web.xml
 - [isuftin@usgs.gov] - tomcat-users template xml header update
@@ -26,6 +35,8 @@ switch to Tomcat startup script
 - [isuftin@usgs.gov] - Updated templates to not get key values using dot notation
 - [isuftin@usgs.gov] - Now working with latest current Chef client version (14.1.1)
 - [isuftin@usgs.gov] - Updated kitchen config to use latest PsiProbe app
+- [isuftin@usgs.gov] - Added the ability to dictate via attributes how many attempts
+to make to check for a running Tomcat server
 - [isuftin@usgs.gov] - Added the ability to dictate via attributes how long to wait
 for timeout when checking against a running Tomcat instance
 - [isuftin@usgs.gov] - Added functionality to the Tomcat instance helper to allow

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,8 +100,12 @@ default['wsi_tomcat']['instances']['default']['context']['attributes']['allow_ca
 default['wsi_tomcat']['instances']['default']['context']['attributes']['background_processor_delay'] = '-1'
 default['wsi_tomcat']['instances']['default']['context']['attributes']['container_sci_filter'] = ''
 
-# The number of seconds to wait while checking to see if a Tomcat instance is ready after starting
-default['wsi_tomcat']['instances']['default']['ready_check_timeout'] = 60
+# The number of attempts tp make while checking to see if a Tomcat instance is
+# ready after starting
+default['wsi_tomcat']['instances']['default']['ready_check_timeout_attempts'] = 120
+# The number of seconds to wait for a response from the server each time there's an
+# attemt to see if it's ready
+default['wsi_tomcat']['instances']['default']['ready_check_timeout_wait'] = 1
 
 # Adds startup java opts to the Tomcat server
 # The default value here speeds up start times considerably

--- a/libraries/tomcat_instance_helper.rb
+++ b/libraries/tomcat_instance_helper.rb
@@ -42,21 +42,20 @@ module Helper
     # Checks if a Tomcat instance is ready by attempting to connect at the
     # instance's port. Will check every 1 second for a specified number of
     # iterations denoted by the max_attempts attribute (default: 60)
-    def self.ready?(node, instance_name = 'default', max_attempts = 60)
+    def self.ready?(node, instance_name = 'default', max_attempts = 60, wait_timeout = 1)
       port = ports(node, instance_name)[0]
 
       check_count = 0
-      Chef::Log.info 'Checking if Tomcat server is ready'
       begin
-        Timeout.timeout(1) do
-          sleep 1
+        Timeout.timeout(wait_timeout) do
           s = TCPSocket.new('127.0.0.1', port)
           s.close
           return true
         end
-      rescue Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      rescue Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT
         check_count += 1
         Chef::Log.info "Tomcat server not yet ready. Check #{check_count} of #{max_attempts}"
+        sleep wait_timeout
         retry if check_count < max_attempts
       end
     end

--- a/providers/instance.rb
+++ b/providers/instance.rb
@@ -232,11 +232,11 @@ def load_service_definitions_and_keys(service_definitions)
             group group
             mode 00600
             sensitive true
-            notifies :run, 'bash[make_keystore_from_new_file]', :delayed
+            notifies :run, "bash[Make Keystore For #{host}]", :delayed
             not_if { ::File.exist?("#{ssl_dir}/#{host}.#{name}.crt") }
           end
 
-          bash 'make_keystore_from_new_file' do
+          bash "Make Keystore For #{host}" do
             cwd ssl_dir
             code <<-EOH
             keytool -import -noprompt -trustcacerts -alias #{host} -file #{ssl_dir}/#{host}.#{name}.crt -keystore truststore -srcstorepass #{keystore_password} -deststorepass #{keystore_password}

--- a/recipes/deploy_application.rb
+++ b/recipes/deploy_application.rb
@@ -6,11 +6,8 @@
 # Description: Deploys application(s) to a specified tomcat instance
 
 tc_node = node['wsi_tomcat']
-node.run_state['wsi_tomcat'] = {
-  'instances' => {}
-}
 
-node['wsi_tomcat']['instances'].each do |instance, attributes|
+tc_node['instances'].each do |instance, attributes|
   # If this instance does not have any applications defined, move on
   next unless attributes.key?('application')
 
@@ -24,42 +21,5 @@ node['wsi_tomcat']['instances'].each do |instance, attributes|
       type application_attributes['type']
       action :deploy
     end
-  end
-
-  # If this instance is not set up to remove applications not in the application
-  # list, move on
-  next unless tc_node['deploy']['remove_unlisted_applications']
-
-  databag_name = tc_node['data_bag_config']['bag_name']
-  credentials_attribute = tc_node['data_bag_config']['credentials_attribute']
-  tomcat_script_pass = data_bag_item(databag_name, credentials_attribute)[instance]['tomcat_script_pass']
-
-  begin
-    # Protects against this block running before a Tomcat instance exists
-    # This really only matters since Helper::ManagerClient.get_deployed_applications
-    # does not check for an instance existing and this spouts out an error
-    # into the logs during cookbook compilation during the first Chef run
-    next unless Helper::TomcatInstance.instance_exists?(node, instance)
-
-    port = Helper::TomcatInstance.ports(node, instance)[0]
-    deployed_apps = Helper::ManagerClient.get_deployed_applications(port, tomcat_script_pass)
-    deployed_apps.each do |path, _state, _session_count, name|
-      version = name.split('#').length > 1 ? name.split('#')[-1] : ''
-      # Don't delete the manager app
-      next unless name != 'manager'
-      next if attributes['application'].keys.include?(name)
-      next unless running
-
-      # TODO : We can probably use the Chef::Helper::ManagerClient to perform this
-      tomcat_application name do
-        instance_name instance
-        version version
-        path path
-        action :undeploy
-      end
-    end
-  rescue => e
-    Chef::Log.error(e)
-    return false
   end
 end

--- a/recipes/undeploy_application.rb
+++ b/recipes/undeploy_application.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: wsi_tomcat
+# Recipe:: undeploy_application
+# Author: Ivan Suftin < isuftin@usgs.gov >
+#
+# Description: Undeploys application(s) from a specified tomcat instance
+
+tc_node = node['wsi_tomcat']
+
+tc_node['instances'].each do |instance, attributes|
+  next unless Helper::TomcatInstance.instance_exists?(node, instance)
+  next unless attributes.key?('application')
+  next unless tc_node['deploy']['remove_unlisted_applications']
+
+  databag_name = tc_node['data_bag_config']['bag_name']
+  credentials_attribute = tc_node['data_bag_config']['credentials_attribute']
+  tomcat_script_pass = data_bag_item(databag_name, credentials_attribute)[instance]['tomcat_script_pass']
+  max_attempts = instance['ready_check_timeout_attempts']
+  check_timeout = instance['ready_check_timeout_wait']
+  next unless Helper::TomcatInstance.ready?(node, instance, max_attempts, check_timeout)
+  port = Helper::TomcatInstance.ports(node, instance)[0]
+  deployed_apps = Helper::ManagerClient.get_deployed_applications(port, tomcat_script_pass, max_attempts, check_timeout)
+  deployed_apps.each do |path, _state, _session_count, name|
+    version = name.split('#').length > 1 ? name.split('#')[-1] : ''
+    # Don't delete the manager app
+    next unless name != 'manager'
+    next if attributes['application'].keys.include?(name)
+
+    # TODO : We can probably use the Chef::Helper::ManagerClient to perform this
+    tomcat_application name do
+      instance_name instance
+      version version
+      path path
+      action :undeploy
+    end
+  end
+end

--- a/recipes/update_context.rb
+++ b/recipes/update_context.rb
@@ -18,8 +18,6 @@ instances.each do |instance, attributes|
 
   if attributes.key?('context')
 
-    Chef::Log.info("Updating #{instance} context")
-
     anti_jar_locking = attributes['context'].fetch(:anti_jar_locking, true)
     anti_resource_locking = attributes['context'].fetch(:anti_resource_locking, true)
     allow_casual_multipart_parsing = attributes['context'].fetch(:allow_casual_multipart_parsing, false)
@@ -79,6 +77,8 @@ instances.each do |instance, attributes|
   tomcat_instance instance do
     action :nothing
   end
+
+  Chef::Log.info("Updating #{instance} context")
 
   template conf_path do
     owner tomcat_user

--- a/resources/application.rb
+++ b/resources/application.rb
@@ -82,12 +82,13 @@ load_current_value do
   instance_script_pass Helper::TomcatInstance.script_pass(node, instance_name)
 
   Chef::Log.info("Checking if Tomcat instance #{instance_name} is ready")
-  wait_time = node['wsi_tomcat']['instances']['default']['ready_check_timeout']
-  unless Helper::TomcatInstance.ready?(node, instance_name, wait_time)
+  max_attempts = node['wsi_tomcat']['instances']['default']['ready_check_timeout_attempts']
+  check_timeout = node['wsi_tomcat']['instances']['default']['ready_check_timeout_wait']
+  unless Helper::TomcatInstance.ready?(node, instance_name, max_attempts, check_timeout)
     raise "Tomcat instance #{instance_name} is not running"
   end
 
-  deployed_apps Helper::ManagerClient.get_deployed_applications(instance_port, instance_script_pass)
+  deployed_apps Helper::ManagerClient.get_deployed_applications(instance_port, instance_script_pass, max_attempts, check_timeout)
   full_name = name.dup
   full_name << "###{version}" unless version.to_s.strip.empty?
   deployed_app_names = deployed_apps.map { |y| y[3] }


### PR DESCRIPTION
- [isuftin@usgs.gov] - In the manager client, the "get_deployed_applications"
function now performs retries
- [isuftin@usgs.gov] - Created a new recipe "undeploy_application" and moved the
application undeploy functionality from the "deploy_application" recipe to this
new recipe. This is a breaking change if you previously depended on the
"deploy_application" to also undeploy applications for you
- [isuftin@usgs.gov] - In the tomcat_application resource, added functionality
to re-try if the "get deployed applications" function didn't work the first time